### PR TITLE
Updated to use latest version of cfssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,19 @@ The signed artefacts can be utilized to prove the integrity of a connector's sof
 
 ## Prerequistes
 
-* Install Go (https://golang.org/doc/install) in a version greater than 1.16.
-Note: The tooling was tested with go version 1.19.2
-* Install Cloudflare's CFSSL used for setting up the PKI
-according to the instructions in https://github.com/cloudflare/cfssl/tree/master.
+**Note:** The tooling was developed and tested on Ubuntu 22.04LTS with go version 1.19.2, and cfssl version 1.6.4.
+
+* Install **Go** (https://golang.org/doc/install) in a version greater than 1.16.  
+* Install Cloudflare's **CFSSL** tool used for setting up the PKI  
+according to the instructions in https://github.com/cloudflare/cfssl/tree/master.  
 The following command can be used for go with a version greater than 1.18:
 ```sh
-$ go install github.com/cloudflare/cfssl/cmd/...@latest
+go install github.com/cloudflare/cfssl/cmd/...@latest
 ```
-Note: The tooling were tested with v1.6.4 of the cffsl tool.
-* Install SqLite3 which is used by CFSSL to manage the databases for OCSP providers
+* Install **SqLite3** which is used by CFSSL to manage the databases for OCSP providers
 ```sh
 sudo apt install sqlite3
 ```
-Note: The tooling were tested on Ubuntu 22.04LTS.
 * Compile the program used for signing artefacts as JSON Web Signature (based on [Go JOSE](https://pkg.go.dev/gopkg.in/square/go-jose.v2))
 ``` sh
 cd pcp_utils

--- a/README.md
+++ b/README.md
@@ -8,15 +8,20 @@ The signed artefacts can be utilized to prove the integrity of a connector's sof
 
 ## Prerequistes
 
+* Install Go (https://golang.org/doc/install) in a version greater than 1.16.
+Note: The tooling was tested with go version 1.19.2
 * Install Cloudflare's CFSSL used for setting up the PKI
+according to the instructions in https://github.com/cloudflare/cfssl/tree/master.
+The following command can be used for go with a version greater than 1.18:
 ```sh
-sudo apt install golang-cfssl
+$ go install github.com/cloudflare/cfssl/cmd/...@latest
 ```
+Note: The tooling were tested with v1.6.4 of the cffsl tool.
 * Install SqLite3 which is used by CFSSL to manage the databases for OCSP providers
 ```sh
 sudo apt install sqlite3
 ```
-* Install Go (https://golang.org/doc/install) which is used for generating the JSON Web Signatures
+Note: The tooling were tested on Ubuntu 22.04LTS.
 * Compile the program used for signing artefacts as JSON Web Signature (based on [Go JOSE](https://pkg.go.dev/gopkg.in/square/go-jose.v2))
 ``` sh
 cd pcp_utils

--- a/pcp_utils/certs_devices.sql
+++ b/pcp_utils/certs_devices.sql
@@ -1,20 +1,24 @@
 CREATE TABLE certificates (
-  serial_number            blob NOT NULL,
-  authority_key_identifier blob NOT NULL,
-  ca_label                 blob,
-  status                   blob NOT NULL,
+  serial_number            varbinary(128) NOT NULL,
+  authority_key_identifier varbinary(128) NOT NULL,
+  ca_label                 varbinary(128),
+  status                   varbinary(128) NOT NULL,
   reason                   int,
-  expiry                   timestamp,
-  revoked_at               timestamp,
-  pem                      blob NOT NULL,
+  expiry                   timestamp DEFAULT '0000-00-00 00:00:00',
+  revoked_at               timestamp DEFAULT '0000-00-00 00:00:00',
+  pem                      varbinary(4096) NOT NULL,
+  issued_at                timestamp DEFAULT '0000-00-00 00:00:00',
+  not_before               timestamp DEFAULT '0000-00-00 00:00:00',
+  metadata                 JSON,
+  sans                     JSON,
+  common_name              TEXT,
   PRIMARY KEY(serial_number, authority_key_identifier)
 );
 
 CREATE TABLE ocsp_responses (
-  serial_number            blob NOT NULL,
-  authority_key_identifier blob NOT NULL,
-  body                     blob NOT NULL,
-  expiry                   timestamp,
-  PRIMARY KEY(serial_number, authority_key_identifier),
-  FOREIGN KEY(serial_number, authority_key_identifier) REFERENCES certificates(serial_number, authority_key_identifier)
+  serial_number            varbinary(128) NOT NULL,
+  authority_key_identifier varbinary(128) NOT NULL,
+  body                     varbinary(4096) NOT NULL,
+  expiry                   timestamp DEFAULT '0000-00-00 00:00:00',
+  PRIMARY KEY(serial_number, authority_key_identifier)
 );

--- a/pcp_utils/certs_subcas.sql
+++ b/pcp_utils/certs_subcas.sql
@@ -1,20 +1,24 @@
 CREATE TABLE certificates (
-  serial_number            blob NOT NULL,
-  authority_key_identifier blob NOT NULL,
-  ca_label                 blob,
-  status                   blob NOT NULL,
+  serial_number            varbinary(128) NOT NULL,
+  authority_key_identifier varbinary(128) NOT NULL,
+  ca_label                 varbinary(128),
+  status                   varbinary(128) NOT NULL,
   reason                   int,
-  expiry                   timestamp,
-  revoked_at               timestamp,
-  pem                      blob NOT NULL,
+  expiry                   timestamp DEFAULT '0000-00-00 00:00:00',
+  revoked_at               timestamp DEFAULT '0000-00-00 00:00:00',
+  pem                      varbinary(4096) NOT NULL,
+  issued_at                timestamp DEFAULT '0000-00-00 00:00:00',
+  not_before               timestamp DEFAULT '0000-00-00 00:00:00',
+  metadata                 JSON,
+  sans                     JSON,
+  common_name              TEXT,
   PRIMARY KEY(serial_number, authority_key_identifier)
 );
 
 CREATE TABLE ocsp_responses (
-  serial_number            blob NOT NULL,
-  authority_key_identifier blob NOT NULL,
-  body                     blob NOT NULL,
-  expiry                   timestamp,
-  PRIMARY KEY(serial_number, authority_key_identifier),
-  FOREIGN KEY(serial_number, authority_key_identifier) REFERENCES certificates(serial_number, authority_key_identifier)
+  serial_number            varbinary(128) NOT NULL,
+  authority_key_identifier varbinary(128) NOT NULL,
+  body                     varbinary(4096) NOT NULL,
+  expiry                   timestamp DEFAULT '0000-00-00 00:00:00',
+  PRIMARY KEY(serial_number, authority_key_identifier)
 );

--- a/pcp_utils/certs_users.sql
+++ b/pcp_utils/certs_users.sql
@@ -1,20 +1,24 @@
 CREATE TABLE certificates (
-  serial_number            blob NOT NULL,
-  authority_key_identifier blob NOT NULL,
-  ca_label                 blob,
-  status                   blob NOT NULL,
+  serial_number            varbinary(128) NOT NULL,
+  authority_key_identifier varbinary(128) NOT NULL,
+  ca_label                 varbinary(128),
+  status                   varbinary(128) NOT NULL,
   reason                   int,
-  expiry                   timestamp,
-  revoked_at               timestamp,
-  pem                      blob NOT NULL,
+  expiry                   timestamp DEFAULT '0000-00-00 00:00:00',
+  revoked_at               timestamp DEFAULT '0000-00-00 00:00:00',
+  pem                      varbinary(4096) NOT NULL,
+  issued_at                timestamp DEFAULT '0000-00-00 00:00:00',
+  not_before               timestamp DEFAULT '0000-00-00 00:00:00',
+  metadata                 JSON,
+  sans                     JSON,
+  common_name              TEXT,
   PRIMARY KEY(serial_number, authority_key_identifier)
 );
 
 CREATE TABLE ocsp_responses (
-  serial_number            blob NOT NULL,
-  authority_key_identifier blob NOT NULL,
-  body                     blob NOT NULL,
-  expiry                   timestamp,
-  PRIMARY KEY(serial_number, authority_key_identifier),
-  FOREIGN KEY(serial_number, authority_key_identifier) REFERENCES certificates(serial_number, authority_key_identifier)
+  serial_number            varbinary(128) NOT NULL,
+  authority_key_identifier varbinary(128) NOT NULL,
+  body                     varbinary(4096) NOT NULL,
+  expiry                   timestamp DEFAULT '0000-00-00 00:00:00',
+  PRIMARY KEY(serial_number, authority_key_identifier)
 );

--- a/pcp_utils/setup_CA.sh
+++ b/pcp_utils/setup_CA.sh
@@ -43,7 +43,7 @@ mkdir -p $DEVICEDIR
 cfssl gencert -initca "$PKIINPUT/ca.json" | cfssljson -bare "$CADIR/ca"
 
 # 2. Set up an OCSP Server for the Root CA
-# Setup the database based on the .sql file derived from ~/go/src/github.com/cloudflare/cfssl/certdb/sqlite/migrations/001_CreateCertificates.sql
+# Setup the database based on the .sql file derived from the files in https://github.com/cloudflare/cfssl/tree/master/certdb/mysql/migrations/
 cat "$PKIINPUT/certs_subcas.sql" | sqlite3 "$OCSPDIR/certdb_subcas.db"
 echo "{\"driver\":\"sqlite3\",\"data_source\":\"$OCSPDIR/certdb_subcas.db\"}" > "$OCSPDIR/sqlite_db_subcas.json"
 


### PR DESCRIPTION
To solve issues with the revocation of issued certificates, we need to use a newer version than the one offered by Ubuntu's package manager. We, therefore, decided to use the latest version from the cfssl repository and edited the README and some configuration files accordingly.